### PR TITLE
CU-27phxeh Adding notebook for some adhoc analyses

### DIFF
--- a/notebooks/Analysis of Percentage Tests PCR vs Antigen.ipynb
+++ b/notebooks/Analysis of Percentage Tests PCR vs Antigen.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a7b64e90",
+   "metadata": {},
+   "source": [
+    "# Analysis of Percentage Tests PCR vs Antigen\n",
+    "\n",
+    "Notebook contains quick analysis of percenage of tests are PCR lab based vs antigen using HHS Protect Data.\n",
+    "\n",
+    "1. Data: HHS Protect Unified State Testing Metrics (Timeseries) HHS Protect [README](https://protect.hhs.gov/workspace/report/ri.report.main.report.90f21a15-7376-4fd8-b2c9-0a88619ed9c5)\n",
+    "    1. Note, this data is also public via [healthdata.gov](https://healthdata.gov/dataset/COVID-19-Diagnostic-Laboratory-Testing-PCR-Testing/j8mb-icvb)\n",
+    "    1. From the README: The metric fields are calculated separately for NAAT (PCR) and Antigen testing. Note that fields without a specification are NAAT definitions. Antigen fields have \"antigen_\" explicitly labelled as a prefix for the field. The following convention is utilized for naming of metric fields: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4c4ff14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime as dt\n",
+    "\n",
+    "import matplotlib\n",
+    "import matplotlib.dates as mdates\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.ticker as mtick\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "\n",
+    "pd.set_option('display.max_rows', 1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0523998e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Local path to a CSV download from HHS Protect; hacky approach. If need to refresh with updated data see links above.\n",
+    "df = pd.read_csv(r'C:\\Users\\ryy0\\inventory\\unified_reporting_results_states_historical.csv')\n",
+    "df['date'] = pd.to_datetime(df['date'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccdd1aab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.daily_sources.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a5cc93c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Checking that the rows are unique at the state and date level\n",
+    "df.groupby(['state', 'date'], dropna=False).size().sort_values(ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9334903",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped = df.groupby(['date']).agg({'new_test_results_reported': np.sum, 'antigen_new_test_results_reported': np.sum})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52a502f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped['new_test_results_reported_7_day_rolling'] = df_grouped['new_test_results_reported'].rolling('7D').sum()\n",
+    "df_grouped['antigen_new_test_results_reported_7_day_rolling'] = df_grouped['antigen_new_test_results_reported'].rolling('7D').sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d471d2e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped['percentage_pcr_daily'] = df_grouped['new_test_results_reported'] / (df_grouped['new_test_results_reported'] + df_grouped['antigen_new_test_results_reported'])\n",
+    "df_grouped['percentage_pcr_7_day_rolling'] = df_grouped['new_test_results_reported_7_day_rolling'] / (df_grouped['new_test_results_reported_7_day_rolling'] + df_grouped['antigen_new_test_results_reported_7_day_rolling'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a3c482e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f19af20b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 1, figsize=(15, 10))\n",
+    "sns.lineplot(x=df_grouped.index, y=df_grouped['percentage_pcr_daily'], ax=ax, alpha=0.4)\n",
+    "sns.lineplot(x=df_grouped.index, y=df_grouped['percentage_pcr_7_day_rolling'], ax=ax)\n",
+    "\n",
+    "ax.set_title('Percentage of COVID-19 Tests that are PCR', fontsize=26)\n",
+    "ax.set_ylabel('Percentage of COVID-19 Tests that are PCR', fontsize=18)\n",
+    "ax.set_xlabel('Date', fontsize=18)\n",
+    "ax.set_xlim(dt.date(2021, 1, 1), dt.date(2021, 12, 31))\n",
+    "ax.set_ylim(0.6, 1)\n",
+    "ax.yaxis.set_major_formatter(mtick.PercentFormatter(1, decimals=0))\n",
+    "\n",
+    "plt.annotate(\n",
+    "    '7-Day Rolling Average of \\nPercentage COVID-19 Tests \\nthat are PCR',\n",
+    "    xy=(dt.date(2021, 12, 7), df_grouped.loc[dt.datetime(2021, 12, 7, 0, 0, 0)]['percentage_pcr_7_day_rolling']),\n",
+    "    xytext=(dt.date(2021, 9, 7), df_grouped.loc[dt.datetime(2021, 12, 7, 0, 0, 0)]['percentage_pcr_7_day_rolling'] + 0.1),\n",
+    "    fontsize=16,\n",
+    "    color='darkorange',\n",
+    "    arrowprops=dict(arrowstyle=\"->\", color='darkorange')\n",
+    ")\n",
+    "\n",
+    "plt.annotate(\n",
+    "    'Daily Percentage \\nof COVID-19 Tests \\nthat are PCR',\n",
+    "    xy=(dt.date(2021, 8, 2), df_grouped.loc[dt.datetime(2021, 8, 2, 0, 0, 0)]['percentage_pcr_daily']),\n",
+    "    xytext=(dt.date(2021, 5, 1), df_grouped.loc[dt.datetime(2021, 8, 1, 0, 0, 0)]['percentage_pcr_daily'] - 0.17),\n",
+    "    fontsize=16,\n",
+    "    color='Blue',\n",
+    "    arrowprops=dict(arrowstyle=\"->\", color='Blue')\n",
+    ")\n",
+    "\n",
+    "ax.tick_params(axis='y', labelsize=14)\n",
+    "\n",
+    "plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))\n",
+    "\n",
+    "plt.savefig(r'C:\\Users\\ryy0\\inventory\\percentage_pcr.png', facecolor='white')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5048bbeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_grouped"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35f0d8e7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
@NatHillardUSDS -- Alicia had asked for some adhoc analysis on percentage of tests that are PCR vs antigen (see Slack Thread [here](https://usds.slack.com/archives/C017N0CS95H/p1641249480222100)). I figured can add notebooks like these to GitHub for transparency. I imagine that this repo will have some adhoc notebooks moving forward so thought it could fit here?